### PR TITLE
docs(validation): newcomer-facing README rewrite

### DIFF
--- a/validation/README.md
+++ b/validation/README.md
@@ -1,17 +1,110 @@
 # ReCiter External-Validation Harness
 
-Scripts to run ReCiter's CARE scoring model against an institution's
-gold-standard publication assertions and evaluate the results — discrimination
-(AUC-ROC), probability calibration (ECE), and manual-review burden.
+This harness measures how well ReCiter's publication-scoring model works at
+institutions it was never trained on.
 
-This harness produced the multi-site external validation reported for the CARE
-methodology: six institutions in the University of California system (UC
-Irvine, UCLA, UC San Diego, UC Davis, UCSF) plus the University of Southern
-California, and Fred Hutchinson Cancer Center. The WCM-trained scoring model is
-applied to each institution's researchers without retraining.
+## What this is, for someone new to ReCiter
 
-It runs ReCiter as a fully local stack — DynamoDB Local, a local PubMed
-retrieval service, and a local scoring service — so no AWS account is required.
+**ReCiter** is an author name disambiguation system: it works out which
+publications belong to a given researcher. The hard part is name collisions —
+telling *your* "J. Smith" apart from the hundreds of other J. Smiths in PubMed.
+
+**CARE** (Composite Author Recognition Engine) is the scoring model inside
+ReCiter. For each candidate article it produces one number from 0 to 100: the
+calibrated confidence that the article belongs to the researcher. A 99 means
+"almost certainly theirs"; a 5 means "almost certainly not."
+
+A **gold standard** is the ground truth for one institution: for each
+researcher, a list of articles a human curator has confirmed (`ACCEPTED`) or
+ruled out (`REJECTED`). It is what the model is scored against.
+
+**External validation** is the question this harness answers. CARE was trained
+on Weill Cornell Medicine data. Does it still work somewhere else — a different
+institution, different researchers, different curation habits — *without being
+retrained*? The only way to know is to run it against another institution's
+gold standard and measure. This harness has done that for seven institutions:
+the six in the UC-system run (UC Irvine, UCLA, USC, UC San Diego, UC Davis,
+UCSF) and Fred Hutchinson Cancer Center.
+
+## What it measures
+
+Scoring every article is only step one. The harness then computes three things:
+
+- **Discrimination (AUC-ROC)** — does the model reliably score real articles
+  above wrong-person articles? 1.0 is perfect ranking.
+- **Calibration (ECE)** — when the model says 90, is the article really theirs
+  about 90% of the time? A well-calibrated score can be trusted as a
+  probability, which is what lets it drive automated accept/reject decisions.
+- **Review burden** — what fraction of articles land in the uncertain middle
+  (score 10–95), where a human still has to look? Lower is better.
+
+## How it works
+
+```
+  Institution's gold standard
+  (researchers + their PMIDs,
+   each ACCEPTED or REJECTED)
+            |
+            v
+  +-----------------------------+
+  |  ReCiter, run locally       |   <- the "local stack": no AWS needed
+  |  - retrieve candidate       |
+  |    articles from PubMed     |
+  |  - compute evidence         |
+  |    features per article     |
+  |  - CARE model -> 0-100      |
+  +-----------------------------+
+            |
+            v
+  +---------------+   +-------------------------+
+  | Evaluation    |   | Review export           |
+  | AUC, ECE,     |   | per-article spreadsheet  |
+  | review burden |   | with a suggested action  |
+  +---------------+   +-------------------------+
+```
+
+1. **Prepare** — `build_uc_validation_data.py` turns a curator's spreadsheet
+   into one CSV per institution (`PersonID, name, PMID, Assertion`).
+2. **Score** — `run_uc_validation_all.sh` (or `run_external_validation.py` for
+   a single institution) runs every researcher through ReCiter and records each
+   article's 0–100 score.
+3. **Evaluate** — `run_external_validation.py --evaluate-only` and
+   `aggregate_uc_evaluation.py` compute AUC, calibration, and review burden,
+   per institution and pooled.
+4. **Export for review** — `build_uc_review_export.py` writes a per-article
+   spreadsheet a curator can act on, each row tagged with a plain-English
+   suggested action (e.g. "Add: very likely missing").
+
+## The local stack, and ReCiter Desktop
+
+ReCiter normally runs in the cloud — on AWS, across Kubernetes (EKS), a scoring
+Lambda, DynamoDB, and separate retrieval services. That is fine for a hosted
+service, but it makes "just run ReCiter on this data" a heavy lift, and it is a
+non-starter for an external institution that has no ReCiter infrastructure.
+
+So this harness runs ReCiter as a **standalone local stack**.
+`start_local_reciter.sh` brings up DynamoDB Local (in Docker), a local PubMed
+retrieval service, a local scoring service, and the ReCiter Java app — all on
+one machine, no AWS account required.
+
+That local stack is the **proof-of-concept for ReCiter Desktop**, the planned
+effort to make ReCiter an installable desktop application anyone can run
+without cloud infrastructure. The relationship is proof-of-concept to product:
+
+- The scripts here — `start_local_reciter.sh`, `stop_local_reciter.sh`,
+  `local_scoring_service.py` — are the first working "ReCiter with no cloud."
+  They were built for this validation work and are driven by shell scripts, not
+  packaged as an application.
+- ReCiter Desktop would productize that: a real installer, a user interface,
+  and no manual stack management.
+
+When ReCiter Desktop matures, this harness would call it instead of managing
+the stack itself — the local-stack scripts here are the seed it grows from. For
+now the two are kept separate: this harness is self-contained so it can be
+cited as one unit by the CARE methodology paper. A reader who only wants to
+reproduce the validation needs nothing from ReCiter Desktop, and a future
+ReCiter Desktop can adopt these scripts without disturbing the paper's frozen
+reference.
 
 ## Layout
 
@@ -51,7 +144,7 @@ export PUBMED_DIR=/path/to/ReCiter-PubMed-Retrieval-Tool
 Researcher data is **not included** — it is identifiable and gitignored. Each
 institution needs a CSV at `external_validation/uc_system/data/<inst>_data.csv`
 with columns: `PersonID, FirstName, MiddleName, LastName, PMID, Assertion`
-(`Assertion` ∈ `ACCEPTED` / `REJECTED`). `build_uc_validation_data.py` derives
+(`Assertion` is `ACCEPTED` or `REJECTED`). `build_uc_validation_data.py` derives
 these from a source spreadsheet.
 
 ## Reproduce a run


### PR DESCRIPTION
## What

Rewrites `validation/README.md` for an uninitiated audience — someone landing on the harness cold, including the UC contact's technical staff and readers who click through from the CARE paper.

The previous README was a technical reproduction guide that assumed familiarity with ReCiter, CARE, gold standards, AUC, and ECE. This version opens with plain-language explanations of each, adds a how-it-works flow diagram (gold standard → local-stack scoring → evaluation + review export), and keeps the technical prerequisites and reproduction steps below.

## ReCiter Desktop

Adds a dedicated section on the local stack and ReCiter Desktop. The harness runs ReCiter with no AWS via `start_local_reciter.sh`; that local stack is the proof-of-concept for ReCiter Desktop. The section frames the relationship as proof-of-concept → product and explains why the two are kept separate for now (the harness stays a self-contained, citable unit for the paper).

Docs-only change. Branched off `dev_v2`; will flow into PR #20 if that is still open.