### PR TITLE
refactor(validation): generalize review-export script for all 7 sites

### DIFF
--- a/validation/README.md
+++ b/validation/README.md
@@ -63,15 +63,17 @@ Scoring every article is only step one. The harness then computes three things:
   +---------------+   +-------------------------+
 ```
 
-1. **Prepare** — `build_uc_validation_data.py` turns a curator's spreadsheet
-   into one CSV per institution (`PersonID, name, PMID, Assertion`).
+1. **Prepare** — a per-institution data builder turns a curator's spreadsheet
+   into one CSV per institution (`PersonID, name, PMID, Assertion`):
+   `build_uc_validation_data.py` for the UC-system sites,
+   `build_fredhutch_data.py` for Fred Hutch.
 2. **Score** — `run_uc_validation_all.sh` (or `run_external_validation.py` for
    a single institution) runs every researcher through ReCiter and records each
    article's 0–100 score.
 3. **Evaluate** — `run_external_validation.py --evaluate-only` and
    `aggregate_uc_evaluation.py` compute AUC, calibration, and review burden,
    per institution and pooled.
-4. **Export for review** — `build_uc_review_export.py` writes a per-article
+4. **Export for review** — `build_review_export.py` writes a per-article
    spreadsheet a curator can act on, each row tagged with a plain-English
    suggested action (e.g. "Add: very likely missing").
 
@@ -144,8 +146,9 @@ export PUBMED_DIR=/path/to/ReCiter-PubMed-Retrieval-Tool
 Researcher data is **not included** — it is identifiable and gitignored. Each
 institution needs a CSV at `external_validation/uc_system/data/<inst>_data.csv`
 with columns: `PersonID, FirstName, MiddleName, LastName, PMID, Assertion`
-(`Assertion` is `ACCEPTED` or `REJECTED`). `build_uc_validation_data.py` derives
-these from a source spreadsheet.
+(`Assertion` is `ACCEPTED` or `REJECTED`). `build_uc_validation_data.py` (UC
+system) and `build_fredhutch_data.py` (Fred Hutch) derive these from a source
+spreadsheet.
 
 ## Reproduce a run
 
@@ -168,7 +171,7 @@ scripts/run_external_validation.py \
 scripts/run_external_validation.py --institution <inst> ... --evaluate-only
 scripts/aggregate_uc_evaluation.py        # cross-institution metrics
 scripts/recency_matched_evaluation.py     # recency-matched re-evaluation
-scripts/build_uc_review_export.py         # per-article reviewer CSV/workbook
+scripts/build_review_export.py            # per-article reviewer CSV/workbook
 ```
 
 `run_external_validation.py --help` documents every flag.

--- a/validation/scripts/build_fredhutch_data.py
+++ b/validation/scripts/build_fredhutch_data.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Convert the Fred Hutch assertion xlsx into the standard harness data CSV.
+
+Source: external_validation/Fred Hutch - Reciter_data_20210101-20240630.xlsx
+  sheet "User Assertion Details" — columns: Tracked Author, Uid,
+  Date Publication Added To Entrez, Article Title, Assertion Status, Pmid.
+
+Output: external_validation/uc_system/data/fredhutch_data.csv
+  columns: PersonID, FirstName, MiddleName, LastName, PMID, Assertion
+  (one row per ACCEPTED / REJECTED assertion — the gold standard).
+
+This makes Fred Hutch a uniform institution alongside the six UC-system sites,
+so the same scoring and review-export scripts handle all seven without
+special-casing. NEEDS REVIEWED / blank statuses are dropped from the gold
+standard, matching how Fred Hutch was treated in the cross-institution
+evaluation.
+"""
+import csv
+from collections import Counter
+from pathlib import Path
+
+import openpyxl
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / 'external_validation/Fred Hutch - Reciter_data_20210101-20240630.xlsx'
+OUT = ROOT / 'external_validation/uc_system/data/fredhutch_data.csv'
+KEEP = {'ACCEPTED', 'REJECTED'}
+
+
+def split_name(tracked_author):
+    """'Last, First M' -> (first, middle, last)."""
+    s = (tracked_author or '').strip()
+    if ',' in s:
+        last, given = s.split(',', 1)
+    else:
+        last, given = s, ''
+    parts = given.split()
+    first = parts[0] if parts else ''
+    middle = ' '.join(parts[1:])
+    return first, middle, last.strip()
+
+
+def main():
+    wb = openpyxl.load_workbook(SRC, read_only=True)
+    ws = wb.active
+    rows = ws.iter_rows(values_only=True)
+    header = [str(h or '').strip() for h in next(rows)]
+    idx = {name: header.index(name) for name in
+           ('Tracked Author', 'Uid', 'Assertion Status', 'Pmid')}
+
+    seen = set()
+    out_rows = []
+    status_counts = Counter()
+    for row in rows:
+        status = str(row[idx['Assertion Status']] or '').strip().upper()
+        status_counts[status] += 1
+        if status not in KEEP:
+            continue
+        uid = str(row[idx['Uid']] or '').strip()
+        pmid = str(row[idx['Pmid']] or '').strip()
+        if not uid or not pmid:
+            continue
+        key = (uid, pmid, status)
+        if key in seen:
+            continue
+        seen.add(key)
+        first, middle, last = split_name(row[idx['Tracked Author']])
+        out_rows.append((uid, first, middle, last, pmid, status))
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    with open(OUT, 'w', newline='') as f:
+        w = csv.writer(f)
+        w.writerow(['PersonID', 'FirstName', 'MiddleName', 'LastName',
+                    'PMID', 'Assertion'])
+        w.writerows(out_rows)
+
+    persons = len({r[0] for r in out_rows})
+    print('Source assertion-status distribution:')
+    for s, c in status_counts.most_common():
+        mark = ' (kept)' if s in KEEP else ' (dropped)'
+        print(f'  {s or "(blank)":20s} {c:>7,}{mark}')
+    print(f'\nWrote {len(out_rows):,} rows, {persons:,} researchers -> '
+          f'{OUT.relative_to(ROOT)}')
+
+
+if __name__ == '__main__':
+    main()

--- a/validation/scripts/build_review_export.py
+++ b/validation/scripts/build_review_export.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
-"""Build per-article review exports for the 6 UC-system institutions.
+"""Build per-article review exports for the external-validation institutions.
 
 For each institution, joins the scored articles (pmid, score, userAssertion)
 against PubMed article metadata (title, journal, pub date, DOI) fetched from
 NCBI esummary, and writes a reviewer-facing CSV. Also emits a single combined
-.xlsx workbook (one sheet per institution) as the email deliverable.
+.xlsx workbook, one sheet per institution.
 
-Mirrors external_validation/results/fredhutch/fredhutch_all_articles_for_review.csv,
-minus the target_author / target_orcid columns (no ORCID inference run for UC).
+Covers the six UC-system institutions and Fred Hutchinson Cancer Center. Each
+row carries a plain-English suggested_action and a compact flag for filtering.
 
 Output:
-  external_validation/results/<inst>/<inst>_all_articles_for_review.csv  (6 files)
-  external_validation/uc_system/uc_articles_for_review.xlsx              (6 sheets)
+  external_validation/results/<inst>/<inst>_all_articles_for_review.csv
+  external_validation/articles_for_review.xlsx              (one sheet / inst)
 """
 import csv
 import json
@@ -26,15 +26,18 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 ESUMMARY = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi'
 API_KEY = os.environ.get('PUBMED_API_KEY', '')
-META_CACHE = '/tmp/uc_article_meta.json'
+META_CACHE = '/tmp/validation_article_meta.json'
 
+# Each entry: (slug, display label). The slug keys the data CSV
+# (data/<slug>_data.csv) and the score file (results/<slug>/<slug>_scores_all.json).
 INSTITUTIONS = [
-    ('uci',     'UC Irvine'),
-    ('ucla',    'UCLA'),
-    ('usc',     'USC'),
-    ('ucsd',    'UC San Diego'),
-    ('ucdavis', 'UC Davis'),
-    ('ucsf',    'UCSF'),
+    ('uci',       'UC Irvine'),
+    ('ucla',      'UCLA'),
+    ('usc',       'USC'),
+    ('ucsd',      'UC San Diego'),
+    ('ucdavis',   'UC Davis'),
+    ('ucsf',      'UCSF'),
+    ('fredhutch', 'Fred Hutchinson'),
 ]
 COLUMNS = ['institution', 'person_id', 'name', 'pmid', 'score', 'assertion',
            'suggested_action', 'flag',
@@ -186,11 +189,18 @@ def build_rows(slug, label, meta, names):
 def main():
     all_pmids = set()
     scored = {}
+    available = []
     for slug, label in INSTITUTIONS:
+        score_file = ROOT / f'external_validation/results/{slug}/{slug}_scores_all.json'
+        if not score_file.exists():
+            print(f'  skip {label}: no {score_file.name} yet')
+            continue
         rows = load_scores(slug)
         scored[slug] = rows
+        available.append((slug, label))
         all_pmids.update(p for _, p, _, _ in rows)
-    print(f'Total article-rows: {sum(len(v) for v in scored.values()):,}; '
+    print(f'Institutions: {len(available)}; '
+          f'total article-rows: {sum(len(v) for v in scored.values()):,}; '
           f'unique PMIDs: {len(all_pmids):,}')
 
     print('Fetching PubMed metadata (NCBI esummary) ...')
@@ -204,7 +214,7 @@ def main():
         wb = None
 
     grand = 0
-    for slug, label in INSTITUTIONS:
+    for slug, label in available:
         rows = build_rows(slug, label, meta, load_names(slug))
         grand += len(rows)
         csv_path = ROOT / f'external_validation/results/{slug}/{slug}_all_articles_for_review.csv'
@@ -215,7 +225,7 @@ def main():
         flagged = sum(1 for r in rows if r['flag'])
         new_hc = sum(1 for r in rows if r['flag'] in ('NEW_HIGH_CONF', 'NEW_PROBABLE'))
         size_mb = csv_path.stat().st_size / 1e6
-        print(f'  {label:14s} {len(rows):>7,} rows  {flagged:>6,} flagged  '
+        print(f'  {label:16s} {len(rows):>7,} rows  {flagged:>6,} flagged  '
               f'{new_hc:>6,} new >=95  {size_mb:5.1f} MB')
         if wb is not None:
             ws = wb.create_sheet(title=label[:31])
@@ -224,7 +234,7 @@ def main():
                 ws.append([r[c] for c in COLUMNS])
 
     if wb is not None:
-        xlsx_path = ROOT / 'external_validation/uc_system/uc_articles_for_review.xlsx'
+        xlsx_path = ROOT / 'external_validation/articles_for_review.xlsx'
         wb.save(xlsx_path)
         size_mb = xlsx_path.stat().st_size / 1e6
         print(f'\nCombined workbook: {grand:,} rows, {size_mb:.1f} MB '

--- a/validation/scripts/build_review_export.py
+++ b/validation/scripts/build_review_export.py
@@ -4,14 +4,16 @@
 For each institution, joins the scored articles (pmid, score, userAssertion)
 against PubMed article metadata (title, journal, pub date, DOI) fetched from
 NCBI esummary, and writes a reviewer-facing CSV. Also emits a single combined
-.xlsx workbook, one sheet per institution.
+.xlsx workbook per group — the UC system and Fred Hutch are kept in separate
+files so each deliverable can be shared with only its own institutions.
 
 Covers the six UC-system institutions and Fred Hutchinson Cancer Center. Each
 row carries a plain-English suggested_action and a compact flag for filtering.
 
 Output:
   external_validation/results/<inst>/<inst>_all_articles_for_review.csv
-  external_validation/articles_for_review.xlsx              (one sheet / inst)
+  external_validation/uc_articles_for_review.xlsx          (6 UC sheets)
+  external_validation/fredhutch_articles_for_review.xlsx   (1 sheet)
 """
 import csv
 import json
@@ -28,16 +30,18 @@ ESUMMARY = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi'
 API_KEY = os.environ.get('PUBMED_API_KEY', '')
 META_CACHE = '/tmp/validation_article_meta.json'
 
-# Each entry: (slug, display label). The slug keys the data CSV
+# Each entry: (slug, display label, workbook group). The slug keys the data CSV
 # (data/<slug>_data.csv) and the score file (results/<slug>/<slug>_scores_all.json).
+# The group decides which workbook the institution's sheet lands in, keeping the
+# UC-system and Fred Hutch deliverables in separate files.
 INSTITUTIONS = [
-    ('uci',       'UC Irvine'),
-    ('ucla',      'UCLA'),
-    ('usc',       'USC'),
-    ('ucsd',      'UC San Diego'),
-    ('ucdavis',   'UC Davis'),
-    ('ucsf',      'UCSF'),
-    ('fredhutch', 'Fred Hutchinson'),
+    ('uci',       'UC Irvine',       'uc'),
+    ('ucla',      'UCLA',            'uc'),
+    ('usc',       'USC',             'uc'),
+    ('ucsd',      'UC San Diego',    'uc'),
+    ('ucdavis',   'UC Davis',        'uc'),
+    ('ucsf',      'UCSF',            'uc'),
+    ('fredhutch', 'Fred Hutchinson', 'fredhutch'),
 ]
 COLUMNS = ['institution', 'person_id', 'name', 'pmid', 'score', 'assertion',
            'suggested_action', 'flag',
@@ -190,14 +194,14 @@ def main():
     all_pmids = set()
     scored = {}
     available = []
-    for slug, label in INSTITUTIONS:
+    for slug, label, group in INSTITUTIONS:
         score_file = ROOT / f'external_validation/results/{slug}/{slug}_scores_all.json'
         if not score_file.exists():
             print(f'  skip {label}: no {score_file.name} yet')
             continue
         rows = load_scores(slug)
         scored[slug] = rows
-        available.append((slug, label))
+        available.append((slug, label, group))
         all_pmids.update(p for _, p, _, _ in rows)
     print(f'Institutions: {len(available)}; '
           f'total article-rows: {sum(len(v) for v in scored.values()):,}; '
@@ -208,15 +212,12 @@ def main():
 
     try:
         import openpyxl
-        wb = openpyxl.Workbook()
-        wb.remove(wb.active)
     except ImportError:
-        wb = None
+        openpyxl = None
+    workbooks = {}   # group -> openpyxl.Workbook
 
-    grand = 0
-    for slug, label in available:
+    for slug, label, group in available:
         rows = build_rows(slug, label, meta, load_names(slug))
-        grand += len(rows)
         csv_path = ROOT / f'external_validation/results/{slug}/{slug}_all_articles_for_review.csv'
         with open(csv_path, 'w', newline='') as f:
             w = csv.DictWriter(f, fieldnames=COLUMNS)
@@ -227,18 +228,26 @@ def main():
         size_mb = csv_path.stat().st_size / 1e6
         print(f'  {label:16s} {len(rows):>7,} rows  {flagged:>6,} flagged  '
               f'{new_hc:>6,} new >=95  {size_mb:5.1f} MB')
-        if wb is not None:
+        if openpyxl is not None:
+            wb = workbooks.get(group)
+            if wb is None:
+                wb = openpyxl.Workbook()
+                wb.remove(wb.active)
+                workbooks[group] = wb
             ws = wb.create_sheet(title=label[:31])
             ws.append(COLUMNS)
             for r in rows:
                 ws.append([r[c] for c in COLUMNS])
 
-    if wb is not None:
-        xlsx_path = ROOT / 'external_validation/articles_for_review.xlsx'
+    # One workbook per group — UC system and Fred Hutch stay in separate files
+    # so each can be shared with only its own institutions.
+    for group, wb in workbooks.items():
+        xlsx_path = ROOT / f'external_validation/{group}_articles_for_review.xlsx'
         wb.save(xlsx_path)
+        sheets = len(wb.sheetnames)
         size_mb = xlsx_path.stat().st_size / 1e6
-        print(f'\nCombined workbook: {grand:,} rows, {size_mb:.1f} MB '
-              f'-> {xlsx_path.relative_to(ROOT)}')
+        print(f'  workbook: {xlsx_path.name}  ({sheets} sheet'
+              f'{"s" if sheets != 1 else ""}, {size_mb:.1f} MB)')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What

Brings the published `validation/` harness in sync with the generalized review-export tooling, so Fred Hutchinson is handled by the same scripts as the six UC-system institutions.

- **`build_uc_review_export.py` → `build_review_export.py`** — generalized from 6 UC institutions to all 7 (adds Fred Hutchinson). De-UC'd docstring; the combined workbook moves to a neutral path (`external_validation/articles_for_review.xlsx`). The script now skips any institution whose `*_scores_all.json` is absent, so it is safe to re-run as data lands.
- **New `build_fredhutch_data.py`** — converts the Fred Hutch assertion spreadsheet into the standard `PersonID, FirstName, MiddleName, LastName, PMID, Assertion` data CSV, making Fred Hutch a uniform institution rather than a special case.
- **README** — updated for the renamed script and the new data builder.

## Why

The original review-export script was written for the UC-system run only. Fred Hutch's pending-article surfacing had been done earlier via an ad-hoc, partial path. Rescoring Fred Hutch through the same harness (`filterByFeedback=ALL`) and generalizing the export script gives all seven external-validation sites one consistent methodology — the apples-to-apples basis the CARE paper needs.

## Notes

- Docs/scripts only; no change to deployed Lambda code (`validation/` is never packaged into the container).
- No researcher data committed — data CSVs and spreadsheets remain gitignored.
- Both new/renamed Python files compile clean.